### PR TITLE
Add changes to `content-disposition` from RFC 6266

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -215,10 +215,28 @@ FormData.prototype._multiPartHeader = function(field, value, options) {
   return '--' + this.getBoundary() + FormData.LINE_BREAK + contents + FormData.LINE_BREAK;
 };
 
+FormData.prototype._encodeHeaderParam = function(str, lang) {
+  if (!lang || typeof lang !== 'string') {
+    lang = '';
+  }
+
+  // taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
+  // @note see RFC 8187
+  return 'UTF-8\'' + lang + '\'' + encodeURIComponent(str).
+    // Note that although RFC3986 reserves "!", RFC8187 does not,
+    // so we do not need to escape it
+    replace(/['()]/g, escape). // i.e., %27 %28 %29
+    replace(/\*/g, '%2A').
+    // The following are not required for percent-encoding per RFC8187,
+    // so we can allow for a little better readability over the wire: |`^
+    replace(/%(?:7C|60|5E)/g, unescape);
+};
+
 FormData.prototype._getContentDisposition = function(value, options) {
 
   var filename
-    , contentDisposition
+    , contentDisposition = []
+    , NON_ASCII_REGEX = /[^\x20-\x7e\xa0-\xff]/g
     ;
 
   if (typeof options.filepath === 'string') {
@@ -236,8 +254,16 @@ FormData.prototype._getContentDisposition = function(value, options) {
     filename = path.basename(value.client._httpMessage.path || '');
   }
 
-  if (typeof filename === 'string') {
-    contentDisposition = 'filename="' + filename + '"';
+  // bail if no valid filename
+  if (typeof filename !== 'string') {
+    return;
+  }
+
+  contentDisposition.push('filename="' + filename + '"');
+
+  // add "filename*" param if filename is not in ASCII
+  if (NON_ASCII_REGEX.test(filename)) {
+    contentDisposition.push('filename*="' + this._encodeHeaderParam(filename) + '"');
   }
 
   return contentDisposition;

--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -222,11 +222,13 @@ FormData.prototype._encodeHeaderParam = function(str, lang) {
 
   // taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
   // @note see RFC 8187
+  // @todo use postman-urlencoder instead of encodeURIComponent for consistency
   return 'UTF-8\'' + lang + '\'' + encodeURIComponent(str).
     // Note that although RFC3986 reserves "!", RFC8187 does not,
     // so we do not need to escape it
-    replace(/['()]/g, escape). // i.e., %27 %28 %29
-    replace(/\*/g, '%2A').
+    replace(/['()*]/g, function(c) {
+      return '%' + c.charCodeAt(0).toString(16);
+    }).
     // The following are not required for percent-encoding per RFC8187,
     // so we can allow for a little better readability over the wire: |`^
     replace(/%(?:7C|60|5E)/g, unescape);
@@ -236,7 +238,7 @@ FormData.prototype._getContentDisposition = function(value, options) {
 
   var filename
     , contentDisposition = []
-    , NON_ASCII_REGEX = /[^\x20-\x7e\xa0-\xff]/g
+    , NON_ASCII_REGEX = /[^\t\x20-\x7e\x80-\xff]/
     ;
 
   if (typeof options.filepath === 'string') {

--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -261,12 +261,11 @@ FormData.prototype._getContentDisposition = function(value, options) {
     return;
   }
 
+  contentDisposition.push('filename="' + filename + '"');
+
   // add "filename*" param if filename is not in ASCII
   if (NON_ASCII_REGEX.test(filename)) {
-    contentDisposition.push('filename="' + encodeURIComponent(filename) + '"');
     contentDisposition.push('filename*="' + this._encodeHeaderParam(filename) + '"');
-  } else {
-    contentDisposition.push('filename="' + filename + '"');
   }
 
   return contentDisposition;

--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -259,11 +259,12 @@ FormData.prototype._getContentDisposition = function(value, options) {
     return;
   }
 
-  contentDisposition.push('filename="' + filename + '"');
-
   // add "filename*" param if filename is not in ASCII
   if (NON_ASCII_REGEX.test(filename)) {
+    contentDisposition.push('filename="' + encodeURIComponent(filename) + '"');
     contentDisposition.push('filename*="' + this._encodeHeaderParam(filename) + '"');
+  } else {
+    contentDisposition.push('filename="' + filename + '"');
   }
 
   return contentDisposition;

--- a/test/integration/test-custom-filename.js
+++ b/test/integration/test-custom-filename.js
@@ -19,7 +19,8 @@ var relativeFile = path.relative(path.join(knownFile, '..', '..'), knownFile);
 
 var options = {
   filename: 'test.png',
-  contentType: 'image/gif'
+  contentType: 'image/gif',
+  _nonAsciiFilename: 'フェニックス.jpg'
 };
 
 var server = http.createServer(function(req, res) {
@@ -59,6 +60,9 @@ var server = http.createServer(function(req, res) {
     assert('unknown_everything' in files);
     assert.strictEqual(files['unknown_everything'].type, FormData.DEFAULT_CONTENT_TYPE, 'Expects default content-type');
 
+    assert('custom_non_ASCII_filename' in files);
+    assert.strictEqual(files['custom_non_ASCII_filename'].name, options._nonAsciiFilename, 'Expects custom non ASCII filename');
+
     res.writeHead(200);
     res.end('done');
   });
@@ -86,6 +90,8 @@ server.listen(common.port, function() {
   form.append('unknown_with_name_prop', customNameStream);
   // No options or implicit file type from extension.
   form.append('unknown_everything', fs.createReadStream(unknownFile));
+
+  form.append('custom_non_ASCII_filename', fs.createReadStream(knownFile), { filename: options._nonAsciiFilename });
 
   common.actions.submit(form, server);
 });

--- a/test/integration/test-custom-filename.js
+++ b/test/integration/test-custom-filename.js
@@ -61,7 +61,7 @@ var server = http.createServer(function(req, res) {
     assert.strictEqual(files['unknown_everything'].type, FormData.DEFAULT_CONTENT_TYPE, 'Expects default content-type');
 
     assert('custom_non_ASCII_filename' in files);
-    assert.strictEqual(files['custom_non_ASCII_filename'].name, encodeURIComponent(options._nonAsciiFilename), 'Expects custom non ASCII filename');
+    assert.strictEqual(files['custom_non_ASCII_filename'].name, options._nonAsciiFilename, 'Expects custom non ASCII filename');
 
     res.writeHead(200);
     res.end('done');

--- a/test/integration/test-custom-filename.js
+++ b/test/integration/test-custom-filename.js
@@ -61,7 +61,7 @@ var server = http.createServer(function(req, res) {
     assert.strictEqual(files['unknown_everything'].type, FormData.DEFAULT_CONTENT_TYPE, 'Expects default content-type');
 
     assert('custom_non_ASCII_filename' in files);
-    assert.strictEqual(files['custom_non_ASCII_filename'].name, options._nonAsciiFilename, 'Expects custom non ASCII filename');
+    assert.strictEqual(files['custom_non_ASCII_filename'].name, encodeURIComponent(options._nonAsciiFilename), 'Expects custom non ASCII filename');
 
     res.writeHead(200);
     res.end('done');

--- a/test/integration/test-get-buffer.js
+++ b/test/integration/test-get-buffer.js
@@ -14,20 +14,28 @@ var FormData = require(common.dir.lib + '/form_data');
 (function testBufferIsValid() {
   var form = new FormData();
 
-  var stringName = 'String';
-  var stringValue = 'This is a random string';
-  var intName = 'Int';
-  var intValue = 1549873167987;
-  var bufferName = 'Buffer';
-  var bufferValue = Buffer.from([0x00,0x4a,0x45,0x46,0x46,0x52,0x45,0x59,0x255]);
-  var emptyFileName = 'EmptyFile';
-  var emptyFileValue = null;
+  var stringName = 'String',
+    stringValue = 'This is a random string',
+    intName = 'Int',
+    intValue = 1549873167987,
+    bufferName = 'Buffer',
+    bufferValue = Buffer.from([0x00,0x4a,0x45,0x46,0x46,0x52,0x45,0x59,0x255]),
+    emptyFileName = 'EmptyFile',
+    asciiFileName = 'AsciiFile',
+    nonAsciiFileName = 'NonAsciiFile',
+    asciiFile = 'file.jpg',
+    nonAsciiFile = 'フェニックス.jpg';
 
   // Fill the formData object
   form.append( stringName, stringValue );
   form.append( intName, intValue );
   form.append( bufferName, bufferValue );
-  form.append( emptyFileName, emptyFileValue, { filename: '' } );
+
+  // @note using `null` here because Stream returned by fs.createReadStream does not work with `getBuffer()`
+  form.append( asciiFileName, null, { filename: asciiFile });
+  form.append( nonAsciiFileName, null, { filename: nonAsciiFile });
+
+  form.append( emptyFileName, null, { filename: '' } );
 
   // Get the resulting Buffer
   var buffer = form.getBuffer();
@@ -45,9 +53,15 @@ var FormData = require(common.dir.lib + '/form_data');
       intValue + FormData.LINE_BREAK +
       '--' + boundary + FormData.LINE_BREAK +
   'Content-Disposition: form-data; name="' + bufferName + '"' + FormData.LINE_BREAK +
-  'Content-Type: application/octet-stream' + FormData.LINE_BREAK +
-    FormData.LINE_BREAK),
+  'Content-Type: application/octet-stream' + FormData.LINE_BREAK + FormData.LINE_BREAK),
     bufferValue,
+    Buffer.from( FormData.LINE_BREAK + '--' + boundary + FormData.LINE_BREAK +
+  'Content-Disposition: form-data; name="' + asciiFileName + '"; filename="' + asciiFile + '"' + FormData.LINE_BREAK +
+  'Content-Type: image/jpeg' + FormData.LINE_BREAK + FormData.LINE_BREAK),
+    Buffer.from( FormData.LINE_BREAK + '--' + boundary + FormData.LINE_BREAK +
+  'Content-Disposition: form-data; name="' + nonAsciiFileName + '"; filename="' + nonAsciiFile +
+      '"; filename*="' + 'UTF-8\'\'%E3%83%95%E3%82%A7%E3%83%8B%E3%83%83%E3%82%AF%E3%82%B9.jpg"' + FormData.LINE_BREAK +
+  'Content-Type: image/jpeg' + FormData.LINE_BREAK + FormData.LINE_BREAK),
     Buffer.from( FormData.LINE_BREAK + '--' + boundary + FormData.LINE_BREAK +
   'Content-Disposition: form-data; name="' + emptyFileName + '"; filename=""' + FormData.LINE_BREAK +
     FormData.LINE_BREAK +

--- a/test/integration/test-get-buffer.js
+++ b/test/integration/test-get-buffer.js
@@ -59,8 +59,10 @@ var FormData = require(common.dir.lib + '/form_data');
   'Content-Disposition: form-data; name="' + asciiFileName + '"; filename="' + asciiFile + '"' + FormData.LINE_BREAK +
   'Content-Type: image/jpeg' + FormData.LINE_BREAK + FormData.LINE_BREAK),
     Buffer.from( FormData.LINE_BREAK + '--' + boundary + FormData.LINE_BREAK +
-  'Content-Disposition: form-data; name="' + nonAsciiFileName + '"; filename="' + nonAsciiFile +
-      '"; filename*="' + 'UTF-8\'\'%E3%83%95%E3%82%A7%E3%83%8B%E3%83%83%E3%82%AF%E3%82%B9.jpg"' + FormData.LINE_BREAK +
+  'Content-Disposition: form-data; name="' + nonAsciiFileName +
+      '"; filename="' + encodeURIComponent(nonAsciiFile) +
+      '"; filename*="' + 'UTF-8\'\'%E3%83%95%E3%82%A7%E3%83%8B%E3%83%83%E3%82%AF%E3%82%B9.jpg"' +
+      FormData.LINE_BREAK +
   'Content-Type: image/jpeg' + FormData.LINE_BREAK + FormData.LINE_BREAK),
     Buffer.from( FormData.LINE_BREAK + '--' + boundary + FormData.LINE_BREAK +
   'Content-Disposition: form-data; name="' + emptyFileName + '"; filename=""' + FormData.LINE_BREAK +

--- a/test/integration/test-get-buffer.js
+++ b/test/integration/test-get-buffer.js
@@ -60,7 +60,7 @@ var FormData = require(common.dir.lib + '/form_data');
   'Content-Type: image/jpeg' + FormData.LINE_BREAK + FormData.LINE_BREAK),
     Buffer.from( FormData.LINE_BREAK + '--' + boundary + FormData.LINE_BREAK +
   'Content-Disposition: form-data; name="' + nonAsciiFileName +
-      '"; filename="' + encodeURIComponent(nonAsciiFile) +
+      '"; filename="' + nonAsciiFile +
       '"; filename*="' + 'UTF-8\'\'%E3%83%95%E3%82%A7%E3%83%8B%E3%83%83%E3%82%AF%E3%82%B9.jpg"' +
       FormData.LINE_BREAK +
   'Content-Type: image/jpeg' + FormData.LINE_BREAK + FormData.LINE_BREAK),


### PR DESCRIPTION
### Support in other clients:
```http
Content-Disposition: attachment; name="file";
	filename="%E3%83%95%E3%82%A7%E3%83%8B%E3%83%83%E3%82%AF%E3%82%B9.jpg";
	filename*="UTF-8''%E3%83%95%E3%82%A7%E3%83%8B%E3%83%83%E3%82%AF%E3%82%B9.jpg"
```
| Client | File saved as |
| ------ | ------------- |
| `curl -OJ` | `%E3%83%95%E3%82%A7%E3%83%8B%E3%83%83%E3%82%AF%E3%82%B9.jpg` |
| `wget --content-disposition` | `フェニックス.jpg` |
| chrome | `フェニックス.jpg` |
| safari | `%E3%83%95%E3%82%A7%E3%83%8B%E3%83%83%E3%82%AF%E3%82%B9.jpg` |

---

```http
Content-Disposition: attachment; name="file";
	filename="??????.jpg";
	filename*="UTF-8''%E3%83%95%E3%82%A7%E3%83%8B%E3%83%83%E3%82%AF%E3%82%B9.jpg"
```
| Client | File saved as |
| ------ | ------------- |
| `curl -OJ` | `??????.jpg` |
| `wget --content-disposition` | `フェニックス.jpg` |
| chrome | `______.jpg` |
| safari | `??????.jpg` |

---

```http
Content-Disposition: attachment; name="file";
	filename="%E3%83%95%E3%82%A7%E3%83%8B%E3%83%83%E3%82%AF%E3%82%B9.jpg"
```
| Client | File saved as |
| ------ | ------------- |
| `curl -OJ` | `%E3%83%95%E3%82%A7%E3%83%8B%E3%83%83%E3%82%AF%E3%82%B9.jpg` |
| `wget --content-disposition` | `フェニックス.jpg` |
| chrome | `フェニックス.jpg` |
| safari | `%E3%83%95%E3%82%A7%E3%83%8B%E3%83%83%E3%82%AF%E3%82%B9.jpg` |

---

```http
Content-Disposition: attachment; name="file";
	filename="??????.jpg"
```
| Client | File saved as |
| ------ | ------------- |
| `curl -OJ` | `??????.jpg` |
| `wget --content-disposition` | `??????.jpg` |
| chrome | `______.jpg` |
| safari | `??????.jpg` |