### PR TITLE
Allow adding empty `filename` param to `content-disposition`

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -46,6 +46,7 @@ FormData.DEFAULT_CONTENT_TYPE = 'application/octet-stream';
 FormData.prototype.append = function(field, value, options) {
 
   options = options || {};
+  value = value || '';
 
   // allow filename as single option
   if (typeof options == 'string') {
@@ -226,11 +227,11 @@ FormData.prototype._getContentDisposition = function(value, options) {
   } else if (typeof options.filename === 'string') {
     // custom filename take precedence
     filename = path.basename(options.filename);
-  } else if (value.name || value.path) {
+  } else if (value && (value.name || value.path)) {
     // formidable and the browser add a name property
     // fs- and request- streams have path property
     filename = path.basename(value.name || value.path);
-  } else if (value.readable && value.hasOwnProperty('httpVersion')) {
+  } else if (value && value.readable && value.hasOwnProperty('httpVersion')) {
     // or try http response
     filename = path.basename(value.client._httpMessage.path || '');
   }
@@ -248,17 +249,17 @@ FormData.prototype._getContentType = function(value, options) {
   var contentType = options.contentType;
 
   // or try `name` from formidable, browser
-  if (!contentType && value.name) {
+  if (!contentType && value && value.name) {
     contentType = mime.lookup(value.name);
   }
 
   // or try `path` from fs-, request- streams
-  if (!contentType && value.path) {
+  if (!contentType && value && value.path) {
     contentType = mime.lookup(value.path);
   }
 
   // or if it's http-reponse
-  if (!contentType && value.readable && value.hasOwnProperty('httpVersion')) {
+  if (!contentType && value && value.readable && value.hasOwnProperty('httpVersion')) {
     contentType = value.headers['content-type'];
   }
 

--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -223,17 +223,19 @@ FormData.prototype._getContentDisposition = function(value, options) {
   if (typeof options.filepath === 'string') {
     // custom filepath for relative paths
     filename = path.normalize(options.filepath).replace(/\\/g, '/');
-  } else if (options.filename || value.name || value.path) {
+  } else if (typeof options.filename === 'string') {
     // custom filename take precedence
+    filename = path.basename(options.filename);
+  } else if (value.name || value.path) {
     // formidable and the browser add a name property
     // fs- and request- streams have path property
-    filename = path.basename(options.filename || value.name || value.path);
+    filename = path.basename(value.name || value.path);
   } else if (value.readable && value.hasOwnProperty('httpVersion')) {
     // or try http response
     filename = path.basename(value.client._httpMessage.path || '');
   }
 
-  if (filename) {
+  if (typeof filename === 'string') {
     contentDisposition = 'filename="' + filename + '"';
   }
 

--- a/test/integration/test-custom-filename.js
+++ b/test/integration/test-custom-filename.js
@@ -37,6 +37,9 @@ var server = http.createServer(function(req, res) {
     assert.strictEqual(files['custom_filename'].name, options.filename, 'Expects custom filename');
     assert.strictEqual(files['custom_filename'].type, mime.lookup(knownFile), 'Expects original content-type');
 
+    assert('empty_filename' in files);
+    assert.strictEqual(files['empty_filename'].name, '', 'Expects empty filename');
+
     assert('custom_filepath' in files);
     assert.strictEqual(files['custom_filepath'].name, relativeFile.replace(/\\/g, '/'), 'Expects custom filepath');
     assert.strictEqual(files['custom_filepath'].type, mime.lookup(knownFile), 'Expects original content-type');
@@ -69,6 +72,8 @@ server.listen(common.port, function() {
   form.append('custom_everything', fs.createReadStream(knownFile), options);
   // Filename only with real file
   form.append('custom_filename', fs.createReadStream(knownFile), options.filename);
+  // Filename only with empty file
+  form.append('empty_filename', '', { filename: '' });
   // Filename only with unknown file
   form.append('unknown_with_filename', fs.createReadStream(unknownFile), options.filename);
   // Filename only with unknown file

--- a/test/integration/test-get-buffer.js
+++ b/test/integration/test-get-buffer.js
@@ -21,7 +21,7 @@ var FormData = require(common.dir.lib + '/form_data');
   var bufferName = 'Buffer';
   var bufferValue = Buffer.from([0x00,0x4a,0x45,0x46,0x46,0x52,0x45,0x59,0x255]);
   var emptyFileName = 'EmptyFile';
-  var emptyFileValue = '';
+  var emptyFileValue = null;
 
   // Fill the formData object
   form.append( stringName, stringValue );

--- a/test/integration/test-get-buffer.js
+++ b/test/integration/test-get-buffer.js
@@ -20,11 +20,14 @@ var FormData = require(common.dir.lib + '/form_data');
   var intValue = 1549873167987;
   var bufferName = 'Buffer';
   var bufferValue = Buffer.from([0x00,0x4a,0x45,0x46,0x46,0x52,0x45,0x59,0x255]);
+  var emptyFileName = 'EmptyFile';
+  var emptyFileValue = '';
 
   // Fill the formData object
   form.append( stringName, stringValue );
   form.append( intName, intValue );
   form.append( bufferName, bufferValue );
+  form.append( emptyFileName, emptyFileValue, { filename: '' } );
 
   // Get the resulting Buffer
   var buffer = form.getBuffer();
@@ -45,7 +48,10 @@ var FormData = require(common.dir.lib + '/form_data');
   'Content-Type: application/octet-stream' + FormData.LINE_BREAK +
     FormData.LINE_BREAK),
     bufferValue,
-    Buffer.from( FormData.LINE_BREAK + '--' + boundary + '--' + FormData.LINE_BREAK )
+    Buffer.from( FormData.LINE_BREAK + '--' + boundary + FormData.LINE_BREAK +
+  'Content-Disposition: form-data; name="' + emptyFileName + '"; filename=""' + FormData.LINE_BREAK +
+    FormData.LINE_BREAK +
+    FormData.LINE_BREAK + '--' + boundary + '--' + FormData.LINE_BREAK )
   ] );
 
   // Test if the buffer content, equals the expected buffer.


### PR DESCRIPTION
Allows adding `filename` as an empty string in `content-disposition`.