### PR TITLE
Replace deprecated util.isArray with Array.isArray

### DIFF
--- a/lib/form_data.js
+++ b/lib/form_data.js
@@ -61,7 +61,7 @@ FormData.prototype.append = function(field, value, options) {
   }
 
   // https://github.com/felixge/node-form-data/issues/38
-  if (util.isArray(value)) {
+  if (Array.isArray(value)) {
     // Please convert your array into string
     // the way web server expects it
     this._error(new Error('Arrays are not supported.'));


### PR DESCRIPTION
Node will now issue a start-up warning when any dep uses util.isArray().

This change replaces a deprecated method with an equivalent supported method.